### PR TITLE
Searching movies on form submit, rather than on button click

### DIFF
--- a/src/Components/SearchMovies.js
+++ b/src/Components/SearchMovies.js
@@ -25,7 +25,7 @@ export default function SearchMovies(props) {
 
   return (
     <div>
-      <form className="form">
+      <form className="form" method="POST" onSubmit={searchMovies} >
         <label className="label" htmlFor="query">
           Movie Name
         </label>
@@ -37,7 +37,7 @@ export default function SearchMovies(props) {
           value={query}
           onChange={handleChange}
         />
-        <button className="button" type="button" onClick={searchMovies}>
+        <button className="button" type="submit">
           Search
         </button>
       </form>


### PR DESCRIPTION
Previously, if the user pressed "Enter" to search movies, the page will reload instead of searching movies.
This was because the default form submission was not prevented. Now the default form submission is prevented, therefore no reload will take place.